### PR TITLE
fix: State.get can return None if key is not found, return a empty TaskQueues

### DIFF
--- a/litestar_saq/config.py
+++ b/litestar_saq/config.py
@@ -126,7 +126,7 @@ class SAQConfig:
         Returns:
             a ``TaskQueues`` instance.
         """
-        return cast("TaskQueues", state.get(self.queues_dependency_key))
+        return cast("TaskQueues", state.get(self.queues_dependency_key, TaskQueues()))
 
     def get_redis(self) -> Redis:
         """Get the configured Redis connection.


### PR DESCRIPTION
`State.get` can return `None` if key is not found, return an empty `TaskQueues` instance from `provide_queues` instead.