### PR TITLE
feat: Support for specific queue startups

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ INFO - 2023-10-04 17:39:03,255 - saq - worker - Worker starting: Queue<redis=Red
 INFO - 2023-10-04 17:39:06,545 - saq - worker - Worker shutting down
 ```
 
-You can also start the process for only specific queues. This is helpful you want separated processes working on different queues instead of combining them. This allows separation of resources.
+You can also start the process for only specific queues. This is helpful if you want separated processes working on different queues instead of combining them.
 
 ```shell
 litestar --app-dir=examples/ --app basic:app workers run --queues sample

--- a/README.md
+++ b/README.md
@@ -35,3 +35,13 @@ Starting SAQ Workers ───────────────────�
 INFO - 2023-10-04 17:39:03,255 - saq - worker - Worker starting: Queue<redis=Redis<ConnectionPool<Connection<host=localhost,port=6397,db=0>>>, name='samples'>
 INFO - 2023-10-04 17:39:06,545 - saq - worker - Worker shutting down
 ```
+
+You can also start the process for only specific queues. This is helpful you want separated processes working on different queues instead of combining them. This allows separation of resources.
+
+```shell
+litestar --app-dir=examples/ --app basic:app workers run --queues sample
+Using Litestar app from env: 'basic:app'
+Starting SAQ Workers ──────────────────────────────────────────────────────────────────
+INFO - 2023-10-04 17:39:03,255 - saq - worker - Worker starting: Queue<redis=Redis<ConnectionPool<Connection<host=localhost,port=6397,db=0>>>, name='samples'>
+INFO - 2023-10-04 17:39:06,545 - saq - worker - Worker shutting down
+```

--- a/litestar_saq/config.py
+++ b/litestar_saq/config.py
@@ -148,6 +148,24 @@ class SAQConfig:
         self.redis = Redis(connection_pool=pool, **self.redis_kwargs)
         return self.redis
 
+    def filter_delete_queues(self, queues: list[str]) -> None:
+        """Remove all the queues except the one passed in.
+
+        Args:
+            queues: The current queues in list.
+
+        Returns:
+            None.
+        """
+        # Remove all queues configs except the ones passed in
+        new_config = [queue_config for queue_config in self.queue_configs if queue_config.name in queues]
+        self.queue_configs = new_config
+        if self.queue_instances is not None:
+            for queue_name in dict(self.queue_instances):
+                if queue_name not in queues:
+                    # Remove all queues instances except the ones passed in
+                    del self.queue_instances[queue_name] # type: ignore  # noqa: PGH003
+
     def get_queues(self) -> TaskQueues:
         """Get the configured SAQ queues.
 

--- a/litestar_saq/plugin.py
+++ b/litestar_saq/plugin.py
@@ -110,6 +110,10 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
         )
         return self._worker_instances
 
+    def remove_workers(self) -> None:
+        self._worker_instances = None
+
+
     def get_queues(self) -> TaskQueues:
         return self._config.get_queues()
 


### PR DESCRIPTION
Allows the command `litestar --app-dir=examples/ --app basic:app workers run --queues sample` to start only with the sample queue.