### PR TITLE
fix: for having unset --queues flag

### DIFF
--- a/litestar_saq/cli.py
+++ b/litestar_saq/cli.py
@@ -64,7 +64,7 @@ def build_cli_app() -> Group:  # noqa: C901
         if debug is not None or verbose is not None:
             app.debug = True
         plugin = get_saq_plugin(app)
-        if queues is not None:
+        if queues:
             queue_list = list(queues)
             limited_start_up(plugin, queue_list)
         show_saq_info(app, workers, plugin)


### PR DESCRIPTION
This fixes an issue where if `--queues` is unset, it would always remove all configured queues. 

The `queues` variable is set to an empty tuple `()` by default and when evaluating it with `queues is not None` would always evaluate to `True`, therefore removing all configured queues.