### PR TITLE
fix: redis port 6397 -> 6379

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ from litestar import Litestar
 
 from litestar_saq import QueueConfig, SAQConfig, SAQPlugin
 
-saq = SAQPlugin(config=SAQConfig(dsn="redis://localhost:6397/0", queue_configs=[QueueConfig(name="samples")]))
+saq = SAQPlugin(config=SAQConfig(dsn="redis://localhost:6379/0", queue_configs=[QueueConfig(name="samples")]))
 app = Litestar(plugins=[saq])
 
 
@@ -29,7 +29,7 @@ You can start a background worker with the following command now:
 litestar --app-dir=examples/ --app basic:app workers run
 Using Litestar app from env: 'basic:app'
 Starting SAQ Workers ──────────────────────────────────────────────────────────────────
-INFO - 2023-10-04 17:39:03,255 - saq - worker - Worker starting: Queue<redis=Redis<ConnectionPool<Connection<host=localhost,port=6397,db=0>>>, name='samples'>
+INFO - 2023-10-04 17:39:03,255 - saq - worker - Worker starting: Queue<redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>, name='samples'>
 INFO - 2023-10-04 17:39:06,545 - saq - worker - Worker shutting down
 ```
 
@@ -39,7 +39,7 @@ You can also start the process for only specific queues. This is helpful if you 
 litestar --app-dir=examples/ --app basic:app workers run --queues sample
 Using Litestar app from env: 'basic:app'
 Starting SAQ Workers ──────────────────────────────────────────────────────────────────
-INFO - 2023-10-04 17:39:03,255 - saq - worker - Worker starting: Queue<redis=Redis<ConnectionPool<Connection<host=localhost,port=6397,db=0>>>, name='samples'>
+INFO - 2023-10-04 17:39:03,255 - saq - worker - Worker starting: Queue<redis=Redis<ConnectionPool<Connection<host=localhost,port=6379,db=0>>>, name='samples'>
 INFO - 2023-10-04 17:39:06,545 - saq - worker - Worker shutting down
 ```
 

--- a/examples/basic.py
+++ b/examples/basic.py
@@ -27,7 +27,7 @@ saq = SAQPlugin(
         use_server_lifespan=True,
         queue_configs=[
             QueueConfig(
-                dsn="redis://localhost:6397/0",
+                dsn="redis://localhost:6379/0",
                 name="samples",
                 tasks=[tasks.background_worker_task, tasks.system_task, tasks.system_upkeep],
                 scheduled_tasks=[CronJob(function=tasks.system_upkeep, cron="* * * * *", timeout=600, ttl=2000)],

--- a/tests/test_cli/__init__.py
+++ b/tests/test_cli/__init__.py
@@ -55,7 +55,7 @@ saq = SAQPlugin(
         use_server_lifespan=True,
         queue_configs=[
             QueueConfig(
-                dsn="redis://localhost:6397/0",
+                dsn="redis://localhost:6379/0",
                 name="samples",
                 tasks=[tasks.background_worker_task, tasks.system_task, tasks.system_upkeep],
                 scheduled_tasks=[CronJob(function=tasks.system_upkeep, cron="* * * * *", timeout=600, ttl=2000)],


### PR DESCRIPTION
The Redis port in the documentation and example code is 6397, while the default Redis port is 6379. This PR changes all occurrences of 6397 to 6379 in the project.