### PR TITLE
fix: use spawn workers on macOS

### DIFF
--- a/litestar_saq/cli.py
+++ b/litestar_saq/cli.py
@@ -23,6 +23,27 @@ DEFAULT_SHUTDOWN_TIMEOUT = 5.0
 SHUTDOWN_BUFFER = 2.0
 
 
+def _resolve_multiprocessing_context(multiprocessing_module: Any, platform_name: str) -> Any:
+    """Resolve multiprocessing context for worker startup.
+
+    Python 3.14 defaults to ``forkserver`` on Linux, which requires picklable
+    process args. Prefer ``fork`` on non-Darwin systems when available so we
+    can run worker objects directly.
+    """
+    if platform_name == "Darwin":
+        multiprocessing_module.set_start_method("spawn", force=True)
+        return multiprocessing_module.get_context("spawn")
+
+    default_ctx = multiprocessing_module.get_context()
+    if default_ctx.get_start_method() != "forkserver":
+        return default_ctx
+
+    try:
+        return multiprocessing_module.get_context("fork")
+    except ValueError:
+        return default_ctx
+
+
 def get_max_shutdown_timeout(workers: "Collection[Worker]") -> float:
     """Calculate the maximum shutdown timeout from worker configurations.
 
@@ -183,7 +204,6 @@ def build_cli_app() -> "Group":  # noqa: C901, PLR0915
     import asyncio
     import multiprocessing
     import platform
-    from typing import cast
 
     from click import IntRange, group, option
     from litestar.cli._utils import LitestarGroup, console  # pyright: ignore
@@ -214,7 +234,7 @@ def build_cli_app() -> "Group":  # noqa: C901, PLR0915
     )
     @option("-v", "--verbose", help="Enable verbose logging.", is_flag=True, default=None, type=bool, required=False)
     @option("-d", "--debug", help="Enable debugging.", is_flag=True, default=None, type=bool, required=False)
-    def run_worker(  # pyright: ignore[reportUnusedFunction]
+    def run_worker(  # pyright: ignore[reportUnusedFunction]  # noqa: C901,PLR0912
         app: "Litestar",
         workers: int,
         queues: "Optional[tuple[str, ...]]",
@@ -223,9 +243,6 @@ def build_cli_app() -> "Group":  # noqa: C901, PLR0915
     ) -> None:
         """Run the API server."""
         console.rule("[yellow]Starting SAQ Workers[/]", align="left")
-        if platform.system() == "Darwin":
-            multiprocessing.set_start_method("spawn", force=True)
-
         if app.logging_config is not None:
             app.logging_config.configure()
         if debug is not None or verbose is not None:
@@ -253,15 +270,14 @@ def build_cli_app() -> "Group":  # noqa: C901, PLR0915
         signal.signal(signal.SIGTERM, handle_shutdown_signal)
         signal.signal(signal.SIGINT, handle_shutdown_signal)
 
-        if platform.system() == "Darwin":
-            ctx = multiprocessing.get_context("spawn")
-        else:
-            ctx = multiprocessing.get_context()
-        use_spawn = ctx.get_start_method() == "spawn"
-        app_path = plugin.config.app_path or os.environ.get("LITESTAR_APP") if use_spawn else None
-        if use_spawn and not app_path:
+        ctx = _resolve_multiprocessing_context(multiprocessing, platform.system())
+        start_method = ctx.get_start_method()
+        requires_reload_by_app_path = start_method in {"spawn", "forkserver"}
+        app_path = plugin.config.app_path or os.environ.get("LITESTAR_APP") if requires_reload_by_app_path else None
+        if requires_reload_by_app_path and not app_path:
             msg = (
-                "SAQ worker spawn requires app_path in SAQConfig or LITESTAR_APP "
+                "SAQ worker start method requiring picklable process args "
+                f"({start_method}) requires app_path in SAQConfig or LITESTAR_APP "
                 "to be set (e.g. 'module:app' or 'module:create_app')."
             )
             raise RuntimeError(msg)
@@ -269,10 +285,10 @@ def build_cli_app() -> "Group":  # noqa: C901, PLR0915
         if workers > 1:
             for _ in range(workers - 1):
                 for worker in managed_workers:
-                    if use_spawn:
+                    if requires_reload_by_app_path:
                         p = ctx.Process(
                             target=run_saq_worker_from_app_path,
-                            args=(cast(str, app_path), worker.queue.name),
+                            args=(cast("str", app_path), worker.queue.name),
                         )
                     else:
                         p = ctx.Process(
@@ -287,10 +303,10 @@ def build_cli_app() -> "Group":  # noqa: C901, PLR0915
 
         if len(managed_workers) > 1:
             for j in range(len(managed_workers) - 1):
-                if use_spawn:
+                if requires_reload_by_app_path:
                     p = ctx.Process(
                         target=run_saq_worker_from_app_path,
-                        args=(cast(str, app_path), managed_workers[j + 1].queue.name),
+                        args=(cast("str", app_path), managed_workers[j + 1].queue.name),
                     )
                 else:
                     p = ctx.Process(target=run_saq_worker, args=(managed_workers[j + 1], app.logging_config))

--- a/litestar_saq/config.py
+++ b/litestar_saq/config.py
@@ -85,6 +85,12 @@ class SAQConfig:
 
     Default is set to 1.
     """
+    app_path: "Optional[str]" = None
+    """Litestar app path to use when spawning worker processes.
+
+    This is required on platforms that must use the "spawn" start method
+    (e.g. macOS) unless the `LITESTAR_APP` environment variable is set.
+    """
 
     json_deserializer: LoadType = decode_json
     """This is a Python callable that will

--- a/litestar_saq/plugin.py
+++ b/litestar_saq/plugin.py
@@ -169,6 +169,27 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
     def get_queue(self, name: str) -> "Queue":
         return self.get_queues().get(name)
 
+    @staticmethod
+    def _resolve_multiprocessing_context(multiprocessing_module: Any, platform_name: str) -> Any:
+        """Resolve multiprocessing context for worker startup.
+
+        Python 3.14 defaults to ``forkserver`` on Linux, which requires picklable
+        process args. SAQ worker instances carry non-picklable state, so prefer
+        ``fork`` on non-Darwin systems when available.
+        """
+        if platform_name == "Darwin":
+            multiprocessing_module.set_start_method("spawn", force=True)
+            return multiprocessing_module.get_context("spawn")
+
+        default_ctx = multiprocessing_module.get_context()
+        if default_ctx.get_start_method() != "forkserver":
+            return default_ctx
+
+        try:
+            return multiprocessing_module.get_context("fork")
+        except ValueError:
+            return default_ctx
+
     @contextmanager
     def server_lifespan(self, app: "Litestar") -> "Iterator[None]":
         import multiprocessing
@@ -178,15 +199,12 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
 
         from litestar_saq.cli import run_saq_worker, run_saq_worker_from_app_path
 
-        if platform.system() == "Darwin":
-            multiprocessing.set_start_method("spawn", force=True)
-
         if not self._config.use_server_lifespan:
             yield
             return
 
         console.rule("[yellow]Starting SAQ Workers[/]", align="left")
-        self._processes: list[Process] = []
+        self._processes: list[Any] = []
         self._shutdown_timeout = self._get_shutdown_timeout()
 
         def handle_shutdown(_signum: Any, _frame: Any) -> None:
@@ -202,26 +220,25 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
         signal.signal(signal.SIGINT, handle_shutdown)
 
         try:
-            if platform.system() == "Darwin":
-                ctx = multiprocessing.get_context("spawn")
-            else:
-                ctx = multiprocessing.get_context()
-            use_spawn = ctx.get_start_method() == "spawn"
-            app_path = self._config.app_path or os.environ.get("LITESTAR_APP") if use_spawn else None
-            if use_spawn and not app_path:
+            ctx = self._resolve_multiprocessing_context(multiprocessing, platform.system())
+            start_method = ctx.get_start_method()
+            requires_reload_by_app_path = start_method in {"spawn", "forkserver"}
+            app_path = self._config.app_path or os.environ.get("LITESTAR_APP") if requires_reload_by_app_path else None
+            if requires_reload_by_app_path and not app_path:
                 msg = (
-                    "SAQ worker spawn requires app_path in SAQConfig or LITESTAR_APP "
+                    "SAQ worker start method requiring picklable process args "
+                    f"({start_method}) requires app_path in SAQConfig or LITESTAR_APP "
                     "to be set (e.g. 'module:app' or 'module:create_app')."
                 )
-                raise RuntimeError(msg)
+                raise RuntimeError(msg)  # noqa: TRY301
 
             for worker_name, worker in self.get_workers().items():
                 for i in range(self.config.worker_processes):
                     console.print(f"[yellow]Starting worker process {i + 1} for {worker_name}[/]")
-                    if use_spawn:
+                    if requires_reload_by_app_path:
                         process = ctx.Process(
                             target=run_saq_worker_from_app_path,
-                            args=(cast(str, app_path), worker_name),
+                            args=(cast("str", app_path), worker_name),
                             name=f"worker-{worker_name}-{i + 1}",
                         )
                     else:
@@ -247,7 +264,7 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
             console.print("[yellow]SAQ workers stopped.[/]")
 
     @staticmethod
-    def _terminate_workers(processes: "list[Process]", timeout: float = DEFAULT_SHUTDOWN_TIMEOUT) -> None:
+    def _terminate_workers(processes: "list[Any]", timeout: float = DEFAULT_SHUTDOWN_TIMEOUT) -> None:
         """Gracefully terminate worker processes with timeout.
 
         Args:

--- a/litestar_saq/plugin.py
+++ b/litestar_saq/plugin.py
@@ -1,9 +1,9 @@
 # pyright: reportUnknownMemberType=false, reportUnknownVariableType=false
+import os
 import signal
 import sys
 import time
 from contextlib import contextmanager
-from multiprocessing import Process
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 from litestar.plugins import CLIPlugin, InitPluginProtocol
@@ -176,10 +176,10 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
 
         from litestar.cli._utils import console  # pyright: ignore
 
-        from litestar_saq.cli import run_saq_worker
+        from litestar_saq.cli import run_saq_worker, run_saq_worker_from_app_path
 
         if platform.system() == "Darwin":
-            multiprocessing.set_start_method("fork", force=True)
+            multiprocessing.set_start_method("spawn", force=True)
 
         if not self._config.use_server_lifespan:
             yield
@@ -202,17 +202,37 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
         signal.signal(signal.SIGINT, handle_shutdown)
 
         try:
+            if platform.system() == "Darwin":
+                ctx = multiprocessing.get_context("spawn")
+            else:
+                ctx = multiprocessing.get_context()
+            use_spawn = ctx.get_start_method() == "spawn"
+            app_path = self._config.app_path or os.environ.get("LITESTAR_APP") if use_spawn else None
+            if use_spawn and not app_path:
+                msg = (
+                    "SAQ worker spawn requires app_path in SAQConfig or LITESTAR_APP "
+                    "to be set (e.g. 'module:app' or 'module:create_app')."
+                )
+                raise RuntimeError(msg)
+
             for worker_name, worker in self.get_workers().items():
                 for i in range(self.config.worker_processes):
                     console.print(f"[yellow]Starting worker process {i + 1} for {worker_name}[/]")
-                    process = Process(
-                        target=run_saq_worker,
-                        args=(
-                            worker,
-                            app.logging_config,
-                        ),
-                        name=f"worker-{worker_name}-{i + 1}",
-                    )
+                    if use_spawn:
+                        process = ctx.Process(
+                            target=run_saq_worker_from_app_path,
+                            args=(cast(str, app_path), worker_name),
+                            name=f"worker-{worker_name}-{i + 1}",
+                        )
+                    else:
+                        process = ctx.Process(
+                            target=run_saq_worker,
+                            args=(
+                                worker,
+                                app.logging_config,
+                            ),
+                            name=f"worker-{worker_name}-{i + 1}",
+                        )
                     process.start()
                     self._processes.append(process)
 

--- a/tests/test_multiprocessing_context.py
+++ b/tests/test_multiprocessing_context.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from litestar_saq.cli import _resolve_multiprocessing_context as resolve_cli_context
+from litestar_saq.plugin import SAQPlugin
+
+
+class _DummyContext:
+    def __init__(self, start_method: str) -> None:
+        self._start_method = start_method
+
+    def get_start_method(self) -> str:
+        return self._start_method
+
+
+class _DummyMultiprocessing:
+    def __init__(self, default_method: str = "forkserver", fork_available: bool = True) -> None:
+        self.default_context = _DummyContext(default_method)
+        self.fork_context = _DummyContext("fork")
+        self.spawn_context = _DummyContext("spawn")
+        self.fork_available = fork_available
+
+    def set_start_method(self, _method: str, force: bool = False) -> None:
+        if not force:
+            msg = "force must be True"
+            raise AssertionError(msg)
+
+    def get_context(self, method: str | None = None) -> _DummyContext:
+        if method is None:
+            return self.default_context
+        if method == "fork":
+            if not self.fork_available:
+                msg = "fork not available"
+                raise ValueError(msg)
+            return self.fork_context
+        if method == "spawn":
+            return self.spawn_context
+        msg = f"Unexpected method: {method}"
+        raise AssertionError(msg)
+
+
+def test_plugin_resolves_fork_for_linux_forkserver() -> None:
+    mp = _DummyMultiprocessing(default_method="forkserver", fork_available=True)
+
+    ctx = SAQPlugin._resolve_multiprocessing_context(mp, "Linux")
+
+    assert ctx.get_start_method() == "fork"
+
+
+def test_plugin_falls_back_when_fork_unavailable() -> None:
+    mp = _DummyMultiprocessing(default_method="forkserver", fork_available=False)
+
+    ctx = SAQPlugin._resolve_multiprocessing_context(mp, "Linux")
+
+    assert ctx.get_start_method() == "forkserver"
+
+
+def test_cli_resolves_spawn_for_darwin() -> None:
+    mp = _DummyMultiprocessing(default_method="fork", fork_available=True)
+
+    ctx = resolve_cli_context(mp, "Darwin")
+
+    assert ctx.get_start_method() == "spawn"


### PR DESCRIPTION
## Summary
- use spawn context explicitly on macOS to avoid fork crashes
- avoid passing Worker instances across process boundaries
- add SAQConfig.app_path fallback for spawn

## Context
On macOS, forking a multithreaded process can crash (seen with torch/MPS). Switching to spawn avoids the crash, but spawn requires picklable process args. Passing Worker instances (which hold threadpool state) causes pickling errors. This change makes macOS always use a spawn context and ensures worker processes are started from the app path instead.

## Testing
- uv run pytest -q
