### PR TITLE
fix: build SAQ workers inside child processes (Python 3.14 forkserver)

### DIFF
--- a/litestar_saq/cli.py
+++ b/litestar_saq/cli.py
@@ -1,12 +1,16 @@
+import asyncio
 import contextlib
+import copy
+import importlib
+import multiprocessing
 import signal
 import sys
 import time
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from dataclasses import dataclass, fields
+from multiprocessing.reduction import ForkingPickler
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 if TYPE_CHECKING:
-    import asyncio
-    import multiprocessing
     from collections.abc import Collection
 
     from click import Group
@@ -48,214 +52,7 @@ def get_max_shutdown_timeout(workers: "Collection[Worker]") -> float:
     return DEFAULT_SHUTDOWN_TIMEOUT
 
 
-def _terminate_worker_processes(
-    processes: "list[multiprocessing.Process]",
-    timeout: float = DEFAULT_SHUTDOWN_TIMEOUT,
-) -> None:
-    """Gracefully terminate worker processes with timeout.
-
-    Args:
-        processes: List of worker processes to terminate
-        timeout: Maximum time to wait for graceful shutdown in seconds.
-            Should be at least as long as the worker's shutdown_grace_period_s
-            plus buffer time for signal propagation.
-    """
-    from litestar.cli._utils import console  # pyright: ignore
-
-    # Send SIGTERM to all processes
-    for p in processes:
-        if p.is_alive():
-            p.terminate()
-
-    # Wait for processes to terminate gracefully
-    termination_start = time.time()
-    while time.time() - termination_start < timeout:
-        if not any(p.is_alive() for p in processes):
-            break
-        time.sleep(0.1)
-
-    # Force kill any remaining processes
-    for p in processes:
-        if p.is_alive():
-            try:
-                p.kill()  # Send SIGKILL
-                p.join(timeout=1.0)
-            except Exception:  # noqa: BLE001
-                console.print(f"[red]Error killing worker process: {p.name}[/]")
-
-
-def _get_event_loop() -> "asyncio.AbstractEventLoop":
-    import asyncio
-
-    try:
-        return asyncio.get_event_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        return loop
-
-
-def _register_shutdown_handlers(
-    loop: "asyncio.AbstractEventLoop",
-    shutdown_event: "asyncio.Event",
-) -> Callable[[], None]:
-    signal_handlers_registered = False
-    fallback_handlers_registered = False
-    original_sigterm: Any = None
-    original_sigint: Any = None
-
-    def request_shutdown() -> None:
-        shutdown_event.set()
-
-    try:
-        loop.add_signal_handler(signal.SIGTERM, request_shutdown)
-        loop.add_signal_handler(signal.SIGINT, request_shutdown)
-        signal_handlers_registered = True
-    except (NotImplementedError, RuntimeError):
-        original_sigterm = signal.getsignal(signal.SIGTERM)
-        original_sigint = signal.getsignal(signal.SIGINT)
-
-        def fallback_handler(_signum: int, _frame: Any) -> None:
-            loop.call_soon_threadsafe(shutdown_event.set)
-
-        try:
-            signal.signal(signal.SIGTERM, fallback_handler)
-            signal.signal(signal.SIGINT, fallback_handler)
-            fallback_handlers_registered = True
-        except ValueError:
-            fallback_handlers_registered = False
-
-    def cleanup() -> None:
-        if signal_handlers_registered:
-            loop.remove_signal_handler(signal.SIGTERM)
-            loop.remove_signal_handler(signal.SIGINT)
-            return
-        if not fallback_handlers_registered:
-            return
-        if original_sigterm is not None:
-            with contextlib.suppress(ValueError):
-                signal.signal(signal.SIGTERM, original_sigterm)
-        if original_sigint is not None:
-            with contextlib.suppress(ValueError):
-                signal.signal(signal.SIGINT, original_sigint)
-
-    return cleanup
-
-
-async def _run_worker_with_shutdown(worker: "Worker") -> None:
-    import asyncio
-
-    loop = asyncio.get_running_loop()
-    shutdown_event = asyncio.Event()
-    cleanup_handlers = _register_shutdown_handlers(loop, shutdown_event)
-
-    try:
-        await worker.queue.connect()
-        worker_task = asyncio.create_task(worker.start())
-        shutdown_task = asyncio.create_task(shutdown_event.wait())
-
-        done, pending = await asyncio.wait(
-            [worker_task, shutdown_task],
-            return_when=asyncio.FIRST_COMPLETED,
-        )
-
-        if worker_task in done:
-            worker_task.result()
-
-        if shutdown_event.is_set():
-            await worker.stop()
-            if not worker_task.done():
-                worker_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await worker_task
-            pending.discard(worker_task)
-
-        for task in pending:
-            task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await task
-    finally:
-        await worker.queue.disconnect()
-        cleanup_handlers()
-
-
-def _prepare_config_for_spawn(config: "SAQConfig") -> "SAQConfig":
-    """Return a deep-copied ``SAQConfig`` safe to pickle into a child process.
-
-    Each :class:`QueueConfig` in the copy has its live ``broker_instance``
-    (and cached broker-type/queue-class state) nulled out so the child can
-    rebuild fresh broker clients lazily from ``dsn``. This is required for
-    Python 3.14+ where ``multiprocessing`` defaults to ``forkserver`` /
-    ``spawn`` start methods, which pickle the target and its args (the live
-    ``redis.asyncio.Redis`` client is not picklable due to lambda-based
-    response callbacks).
-
-    Args:
-        config: The application's :class:`SAQConfig`.
-
-    Returns:
-        A deep-copied, pickle-safe :class:`SAQConfig`.
-
-    Raises:
-        ImproperConfigurationError: If any :class:`QueueConfig` was constructed
-            with only ``broker_instance`` and no ``dsn``. Such queues cannot
-            be rebuilt inside the child process.
-    """
-    import copy
-
-    from litestar_saq.exceptions import ImproperConfigurationError
-
-    for qc in config.queue_configs:
-        if qc.broker_instance is not None and not qc.dsn:
-            msg = (
-                f"QueueConfig(name={qc.name!r}) was constructed with "
-                "`broker_instance` and no `dsn`. Multi-process worker spawning "
-                "requires a `dsn` so the broker can be rebuilt inside the "
-                "child process. Provide a `dsn` or run with "
-                "`separate_process=False`."
-            )
-            raise ImproperConfigurationError(msg)
-
-    prepared = copy.deepcopy(config)
-    # Null out the live queue instances on the config itself — these hold live
-    # broker clients that are not picklable under forkserver/spawn.
-    prepared.queue_instances = None
-    for qc in prepared.queue_configs:
-        qc.broker_instance = None
-        qc._broker_type = None  # noqa: SLF001
-        qc._queue_class = None  # noqa: SLF001
-    return prepared
-
-
-def _run_worker_in_child(
-    queue_name: str,
-    config: "SAQConfig",
-    logging_config: "Optional[BaseLoggingConfig]",
-) -> None:
-    """Reconstruct the ``Worker`` inside the child process and run it.
-
-    This is the multiprocessing ``target`` for spawned workers. It must be
-    a top-level function so ``forkserver`` / ``spawn`` can pickle it. The
-    ``config`` argument must have been passed through
-    :func:`_prepare_config_for_spawn` first.
-
-    Args:
-        queue_name: Name of the queue this child should run.
-        config: Pickle-safe :class:`SAQConfig` (no live ``broker_instance``).
-        logging_config: Optional logging configuration to apply in the child.
-    """
-    from litestar_saq.plugin import SAQPlugin
-
-    plugin = SAQPlugin(config=config)
-    worker = plugin.get_workers()[queue_name]
-    run_saq_worker(worker, logging_config)
-
-
 def build_cli_app() -> "Group":  # noqa: C901, PLR0915
-    import asyncio
-    import multiprocessing
-    from typing import cast
-
     from click import IntRange, group, option
     from litestar.cli._utils import LitestarGroup, console  # pyright: ignore
 
@@ -322,14 +119,19 @@ def build_cli_app() -> "Group":  # noqa: C901, PLR0915
         signal.signal(signal.SIGTERM, handle_shutdown_signal)
         signal.signal(signal.SIGINT, handle_shutdown_signal)
 
-        spawn_config = _prepare_config_for_spawn(plugin.config)
+        requires_child_processes = workers > 1 or len(managed_queue_names) > 1
+        requires_safe_args = requires_child_processes and requires_multiprocessing_safe_args()
+        child_config = prepare_config_for_spawn(plugin.config) if requires_safe_args else plugin.config
+        child_logging_config = (
+            prepare_logging_config_for_spawn(app.logging_config) if requires_safe_args else app.logging_config
+        )
 
         if workers > 1:
             for _ in range(workers - 1):
                 for queue_name in managed_queue_names:
                     p = multiprocessing.Process(
-                        target=_run_worker_in_child,
-                        args=(queue_name, spawn_config, app.logging_config),
+                        target=run_worker_in_child,
+                        args=(queue_name, child_config, child_logging_config),
                     )
                     p.start()
                     processes.append(p)
@@ -337,8 +139,8 @@ def build_cli_app() -> "Group":  # noqa: C901, PLR0915
         if len(managed_queue_names) > 1:
             for j in range(len(managed_queue_names) - 1):
                 p = multiprocessing.Process(
-                    target=_run_worker_in_child,
-                    args=(managed_queue_names[j + 1], spawn_config, app.logging_config),
+                    target=run_worker_in_child,
+                    args=(managed_queue_names[j + 1], child_config, child_logging_config),
                 )
                 p.start()
                 processes.append(p)
@@ -392,12 +194,10 @@ def get_saq_plugin(app: "Litestar") -> "SAQPlugin":
     Raises:
         ImproperConfigurationError: If the SAQ plugin is not found.
     """
-    from contextlib import suppress
-
     from litestar_saq.exceptions import ImproperConfigurationError
     from litestar_saq.plugin import SAQPlugin
 
-    with suppress(KeyError):
+    with contextlib.suppress(KeyError):
         return app.plugins.get(SAQPlugin)
     msg = "Failed to initialize SAQ. The required plugin (SAQPlugin) is missing."
     raise ImproperConfigurationError(
@@ -424,7 +224,7 @@ def show_saq_info(app: "Litestar", workers: int, plugin: "SAQPlugin") -> None:  
     console.print(table)
 
 
-def run_saq_worker(worker: "Worker", logging_config: "Optional[BaseLoggingConfig]") -> None:
+def run_saq_worker(worker: "Worker", logging_config: "Optional[Any]") -> None:
     """Run a worker.
 
     Args:
@@ -444,9 +244,393 @@ def run_saq_worker(worker: "Worker", logging_config: "Optional[BaseLoggingConfig
         worker.configure_structlog_context()
         if isinstance(logging_config, StructLoggingConfig) and logging_config.standard_lib_logging_config is not None:
             logging_config.standard_lib_logging_config.configure()
+        if isinstance(logging_config, _SpawnLoggingConfig):
+            logging_config.configure_standard_lib_logging()
 
     try:
         if worker.separate_process:
             loop.run_until_complete(_run_worker_with_shutdown(worker))
     except KeyboardInterrupt:
         loop.run_until_complete(loop.create_task(worker.stop()))
+
+
+def requires_multiprocessing_safe_args() -> bool:
+    """Return whether child worker arguments must be pickle-safe."""
+    return multiprocessing.get_start_method() != "fork"
+
+
+def prepare_logging_config_for_spawn(
+    logging_config: "Optional[BaseLoggingConfig]",
+) -> "Optional[Any]":
+    """Return a pickle-safe logging config for worker child processes.
+
+    Raises:
+        ImproperConfigurationError: If the logging config cannot be pickled for child worker processes.
+    """
+    from litestar.logging.config import LoggingConfig, StructLoggingConfig
+
+    from litestar_saq.exceptions import ImproperConfigurationError
+
+    if logging_config is None:
+        return None
+
+    if isinstance(logging_config, LoggingConfig):
+        logging_module, log_dictconfig = _logging_config_to_dict(logging_config)
+        prepared: Any = _SpawnLoggingConfig(logging_config=log_dictconfig, logging_module=logging_module)
+    elif isinstance(logging_config, StructLoggingConfig):
+        structlog_config = _structlog_config_to_dict(logging_config)
+        standard_lib_logging_config = None
+        standard_lib_logging_module = "logging"
+        if logging_config.standard_lib_logging_config is not None:
+            standard_lib_logging_module, standard_lib_logging_config = _logging_config_to_dict(
+                logging_config.standard_lib_logging_config
+            )
+        prepared = _SpawnLoggingConfig(
+            structlog_config=structlog_config,
+            standard_lib_logging_config=standard_lib_logging_config,
+            standard_lib_logging_module=standard_lib_logging_module,
+        )
+    else:
+        prepared = logging_config
+
+    try:
+        ForkingPickler.dumps(prepared)
+    except Exception as e:
+        msg = (
+            f"{type(logging_config).__name__} cannot be pickled for multi-process SAQ workers. "
+            "Use Litestar LoggingConfig or StructLoggingConfig with pickle-safe custom callables, "
+            "or disable child worker processes."
+        )
+        raise ImproperConfigurationError(msg) from e
+    return prepared
+
+
+def prepare_config_for_spawn(config: "SAQConfig") -> "SAQConfig":
+    """Return a deep-copied ``SAQConfig`` safe to pickle into a child process.
+
+    Each :class:`QueueConfig` in the copy has its live ``broker_instance``
+    (and cached broker-type/queue-class state) nulled out so the child can
+    rebuild fresh broker clients lazily from ``dsn``. This is required for
+    Python 3.14+ where ``multiprocessing`` defaults to ``forkserver`` /
+    ``spawn`` start methods, which pickle the target and its args (the live
+    ``redis.asyncio.Redis`` client is not picklable due to lambda-based
+    response callbacks).
+
+    Args:
+        config: The application's :class:`SAQConfig`.
+
+    Returns:
+        A deep-copied, pickle-safe :class:`SAQConfig`.
+
+    Raises:
+        ImproperConfigurationError: If any :class:`QueueConfig` was constructed
+            with only ``broker_instance`` and no ``dsn``. Such queues cannot
+            be rebuilt inside the child process.
+    """
+    from litestar_saq.exceptions import ImproperConfigurationError
+
+    for qc in config.queue_configs:
+        if qc.broker_instance is not None and not qc.dsn:
+            msg = (
+                f"QueueConfig(name={qc.name!r}) was constructed with "
+                "`broker_instance` and no `dsn`. Multi-process worker spawning "
+                "requires a `dsn` so the broker can be rebuilt inside the "
+                "child process. Provide a `dsn` or run with "
+                "`separate_process=False`."
+            )
+            raise ImproperConfigurationError(msg)
+
+    prepared = copy.deepcopy(config)
+    # Null out the live queue instances on the config itself; these hold live
+    # broker clients that are not picklable under forkserver/spawn.
+    prepared.queue_instances = None
+    for qc in prepared.queue_configs:
+        qc.broker_instance = None
+        setattr(qc, "_broker_type", None)
+        setattr(qc, "_queue_class", None)
+    return prepared
+
+
+def run_worker_in_child(
+    queue_name: str,
+    config: "SAQConfig",
+    logging_config: "Optional[Any]",
+) -> None:
+    """Reconstruct the ``Worker`` inside the child process and run it.
+
+    This is the multiprocessing ``target`` for spawned workers. It must be
+    a top-level function so ``forkserver`` / ``spawn`` can pickle it. The
+    ``config`` argument must have been passed through
+    :func:`prepare_config_for_spawn` first.
+
+    Args:
+        queue_name: Name of the queue this child should run.
+        config: Pickle-safe :class:`SAQConfig` (no live ``broker_instance``).
+        logging_config: Optional logging configuration to apply in the child.
+    """
+    from litestar_saq.plugin import SAQPlugin
+
+    plugin = SAQPlugin(config=config)
+    worker = plugin.get_workers()[queue_name]
+    run_saq_worker(worker, logging_config)
+
+
+_QUEUE_HANDLER_CLASSES = (
+    "litestar.logging.standard.QueueListenerHandler",
+    "logging.handlers.QueueHandler",
+    "logging.handlers.QueueListener",
+)
+
+
+@dataclass
+class _SpawnLoggingConfig:
+    """Pickle-safe logging config snapshot for worker child processes."""
+
+    logging_config: "Optional[dict[str, Any]]" = None
+    logging_module: str = "logging"
+    structlog_config: "Optional[dict[str, Any]]" = None
+    standard_lib_logging_config: "Optional[dict[str, Any]]" = None
+    standard_lib_logging_module: str = "logging"
+
+    def configure(self) -> Callable[[str], Any]:
+        logger_factory: Optional[Callable[[str], Any]] = None
+        if self.structlog_config is not None:
+            try:
+                import structlog
+            except ImportError as e:
+                from litestar.exceptions import MissingDependencyException
+
+                msg = "structlog"
+                raise MissingDependencyException(msg) from e
+            logger_factory = structlog.get_logger
+            structlog.configure(**self.structlog_config)
+        if self.logging_config is not None:
+            logger_factory = _configure_logging_dict(self.logging_module, self.logging_config)
+        if logger_factory is None:
+            from logging import getLogger
+
+            logger_factory = getLogger
+        return logger_factory
+
+    def configure_standard_lib_logging(self) -> Callable[[str], Any]:
+        if self.standard_lib_logging_config is not None:
+            return _configure_logging_dict(self.standard_lib_logging_module, self.standard_lib_logging_config)
+        from logging import getLogger
+
+        return getLogger
+
+
+def _configure_logging_dict(logging_module: str, logging_config: "dict[str, Any]") -> Callable[[str], Any]:
+    if logging_module == "picologging":
+        try:
+            logging = importlib.import_module("picologging")
+            logging_config_module = importlib.import_module("picologging.config")
+        except ImportError as e:
+            from litestar.exceptions import MissingDependencyException
+
+            msg = "picologging"
+            raise MissingDependencyException(msg) from e
+        get_logger = cast("Callable[[str], Any]", logging.getLogger)
+        dict_config = logging_config_module.dictConfig
+    else:
+        from logging import config, getLogger
+
+        get_logger = getLogger
+        dict_config = config.dictConfig
+
+    dict_config(copy.deepcopy(logging_config))
+    return get_logger
+
+
+def _is_queue_handler(handler: "dict[str, Any]") -> bool:
+    handler_class = handler.get("class") or handler.get("()")
+    if isinstance(handler_class, str) and any(cls in handler_class for cls in _QUEUE_HANDLER_CLASSES):
+        return True
+    if isinstance(handler_class, type):
+        handler_path = f"{handler_class.__module__}.{handler_class.__qualname__}"
+        if any(cls in handler_path for cls in _QUEUE_HANDLER_CLASSES):
+            return True
+    return "listener" in handler
+
+
+def _neutralize_queue_handlers_for_spawn(logging_config: "dict[str, Any]") -> None:
+    handlers = logging_config.get("handlers")
+    if not isinstance(handlers, dict):
+        return
+    typed_handlers = cast("dict[str, Any]", handlers)
+    for name, handler in list(typed_handlers.items()):
+        if not isinstance(handler, dict):
+            continue
+        handler_config = cast("dict[str, Any]", handler)
+        if not _is_queue_handler(handler_config):
+            continue
+        replacement: dict[str, Any] = {"class": "logging.StreamHandler"}
+        if "formatter" in handler_config:
+            replacement["formatter"] = handler_config["formatter"]
+        if "level" in handler_config:
+            replacement["level"] = handler_config["level"]
+        typed_handlers[name] = replacement
+
+
+def _terminate_worker_processes(
+    processes: "list[multiprocessing.Process]",
+    timeout: float = DEFAULT_SHUTDOWN_TIMEOUT,
+) -> None:
+    """Gracefully terminate worker processes with timeout.
+
+    Args:
+        processes: List of worker processes to terminate
+        timeout: Maximum time to wait for graceful shutdown in seconds.
+            Should be at least as long as the worker's shutdown_grace_period_s
+            plus buffer time for signal propagation.
+    """
+    from litestar.cli._utils import console  # pyright: ignore
+
+    for p in processes:
+        if p.is_alive():
+            p.terminate()
+
+    termination_start = time.time()
+    while time.time() - termination_start < timeout:
+        if not any(p.is_alive() for p in processes):
+            break
+        time.sleep(0.1)
+
+    for p in processes:
+        if p.is_alive():
+            try:
+                p.kill()
+                p.join(timeout=1.0)
+            except Exception:  # noqa: BLE001
+                console.print(f"[red]Error killing worker process: {p.name}[/]")
+
+
+def _get_event_loop() -> "asyncio.AbstractEventLoop":
+    try:
+        return asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
+
+
+def _register_shutdown_handlers(
+    loop: "asyncio.AbstractEventLoop",
+    shutdown_event: "asyncio.Event",
+) -> Callable[[], None]:
+    signal_handlers_registered = False
+    fallback_handlers_registered = False
+    original_sigterm: Any = None
+    original_sigint: Any = None
+
+    def request_shutdown() -> None:
+        shutdown_event.set()
+
+    try:
+        loop.add_signal_handler(signal.SIGTERM, request_shutdown)
+        loop.add_signal_handler(signal.SIGINT, request_shutdown)
+        signal_handlers_registered = True
+    except (NotImplementedError, RuntimeError):
+        original_sigterm = signal.getsignal(signal.SIGTERM)
+        original_sigint = signal.getsignal(signal.SIGINT)
+
+        def fallback_handler(_signum: int, _frame: Any) -> None:
+            loop.call_soon_threadsafe(shutdown_event.set)
+
+        try:
+            signal.signal(signal.SIGTERM, fallback_handler)
+            signal.signal(signal.SIGINT, fallback_handler)
+            fallback_handlers_registered = True
+        except ValueError:
+            fallback_handlers_registered = False
+
+    def cleanup() -> None:
+        if signal_handlers_registered:
+            loop.remove_signal_handler(signal.SIGTERM)
+            loop.remove_signal_handler(signal.SIGINT)
+            return
+        if not fallback_handlers_registered:
+            return
+        if original_sigterm is not None:
+            with contextlib.suppress(ValueError):
+                signal.signal(signal.SIGTERM, original_sigterm)
+        if original_sigint is not None:
+            with contextlib.suppress(ValueError):
+                signal.signal(signal.SIGINT, original_sigint)
+
+    return cleanup
+
+
+async def _run_worker_with_shutdown(worker: "Worker") -> None:
+    loop = asyncio.get_running_loop()
+    shutdown_event = asyncio.Event()
+    cleanup_handlers = _register_shutdown_handlers(loop, shutdown_event)
+
+    try:
+        await worker.queue.connect()
+        worker_task = asyncio.create_task(worker.start())
+        shutdown_task = asyncio.create_task(shutdown_event.wait())
+
+        done, pending = await asyncio.wait(
+            [worker_task, shutdown_task],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        if worker_task in done:
+            worker_task.result()
+
+        if shutdown_event.is_set():
+            await worker.stop()
+            if not worker_task.done():
+                worker_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await worker_task
+            pending.discard(worker_task)
+
+        for task in pending:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+    finally:
+        await worker.queue.disconnect()
+        cleanup_handlers()
+
+
+def _logging_config_to_dict(logging_config: Any) -> "tuple[str, dict[str, Any]]":
+    excluded_fields = {
+        "logging_module",
+        "configure_root_logger",
+        "exception_logging_handler",
+        "log_exceptions",
+        "propagate",
+        "traceback_line_limit",
+        "disable_stack_trace",
+    }
+    if not logging_config.configure_root_logger:
+        excluded_fields.add("root")
+    if logging_config.logging_module == "picologging":
+        excluded_fields.add("incremental")
+
+    log_dictconfig = {
+        field.name: copy.deepcopy(getattr(logging_config, field.name))
+        for field in fields(logging_config)
+        if getattr(logging_config, field.name) is not None and field.name not in excluded_fields
+    }
+    _neutralize_queue_handlers_for_spawn(log_dictconfig)
+    return logging_config.logging_module, log_dictconfig
+
+
+def _structlog_config_to_dict(logging_config: Any) -> "dict[str, Any]":
+    excluded_fields = {
+        "standard_lib_logging_config",
+        "log_exceptions",
+        "traceback_line_limit",
+        "exception_logging_handler",
+        "pretty_print_tty",
+        "disable_stack_trace",
+    }
+    return {
+        field.name: copy.deepcopy(getattr(logging_config, field.name))
+        for field in fields(logging_config)
+        if getattr(logging_config, field.name) is not None and field.name not in excluded_fields
+    }

--- a/litestar_saq/cli.py
+++ b/litestar_saq/cli.py
@@ -224,6 +224,30 @@ def _prepare_config_for_spawn(config: "SAQConfig") -> "SAQConfig":
     return prepared
 
 
+def _run_worker_in_child(
+    queue_name: str,
+    config: "SAQConfig",
+    logging_config: "Optional[BaseLoggingConfig]",
+) -> None:
+    """Reconstruct the ``Worker`` inside the child process and run it.
+
+    This is the multiprocessing ``target`` for spawned workers. It must be
+    a top-level function so ``forkserver`` / ``spawn`` can pickle it. The
+    ``config`` argument must have been passed through
+    :func:`_prepare_config_for_spawn` first.
+
+    Args:
+        queue_name: Name of the queue this child should run.
+        config: Pickle-safe :class:`SAQConfig` (no live ``broker_instance``).
+        logging_config: Optional logging configuration to apply in the child.
+    """
+    from litestar_saq.plugin import SAQPlugin
+
+    plugin = SAQPlugin(config=config)
+    worker = plugin.get_workers()[queue_name]
+    run_saq_worker(worker, logging_config)
+
+
 def build_cli_app() -> "Group":  # noqa: C901, PLR0915
     import asyncio
     import multiprocessing

--- a/litestar_saq/cli.py
+++ b/litestar_saq/cli.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from litestar.logging.config import BaseLoggingConfig
 
     from litestar_saq.base import Worker
+    from litestar_saq.config import SAQConfig
     from litestar_saq.plugin import SAQPlugin
 
 # Default timeout for graceful shutdown when no grace period is configured
@@ -176,6 +177,51 @@ async def _run_worker_with_shutdown(worker: "Worker") -> None:
     finally:
         await worker.queue.disconnect()
         cleanup_handlers()
+
+
+def _prepare_config_for_spawn(config: "SAQConfig") -> "SAQConfig":
+    """Return a deep-copied ``SAQConfig`` safe to pickle into a child process.
+
+    Each :class:`QueueConfig` in the copy has its live ``broker_instance``
+    (and cached broker-type/queue-class state) nulled out so the child can
+    rebuild fresh broker clients lazily from ``dsn``. This is required for
+    Python 3.14+ where ``multiprocessing`` defaults to ``forkserver`` /
+    ``spawn`` start methods, which pickle the target and its args (the live
+    ``redis.asyncio.Redis`` client is not picklable due to lambda-based
+    response callbacks).
+
+    Args:
+        config: The application's :class:`SAQConfig`.
+
+    Returns:
+        A deep-copied, pickle-safe :class:`SAQConfig`.
+
+    Raises:
+        ImproperConfigurationError: If any :class:`QueueConfig` was constructed
+            with only ``broker_instance`` and no ``dsn``. Such queues cannot
+            be rebuilt inside the child process.
+    """
+    import copy
+
+    from litestar_saq.exceptions import ImproperConfigurationError
+
+    for qc in config.queue_configs:
+        if qc.broker_instance is not None and not qc.dsn:
+            msg = (
+                f"QueueConfig(name={qc.name!r}) was constructed with "
+                "`broker_instance` and no `dsn`. Multi-process worker spawning "
+                "requires a `dsn` so the broker can be rebuilt inside the "
+                "child process. Provide a `dsn` or run with "
+                "`separate_process=False`."
+            )
+            raise ImproperConfigurationError(msg)
+
+    prepared = copy.deepcopy(config)
+    for qc in prepared.queue_configs:
+        qc.broker_instance = None
+        qc._broker_type = None  # noqa: SLF001
+        qc._queue_class = None  # noqa: SLF001
+    return prepared
 
 
 def build_cli_app() -> "Group":  # noqa: C901, PLR0915

--- a/litestar_saq/cli.py
+++ b/litestar_saq/cli.py
@@ -340,15 +340,24 @@ def prepare_config_for_spawn(config: "SAQConfig") -> "SAQConfig":
             )
             raise ImproperConfigurationError(msg)
 
-    prepared = copy.deepcopy(config)
-    # Null out the live queue instances on the config itself; these hold live
-    # broker clients that are not picklable under forkserver/spawn.
-    prepared.queue_instances = None
-    for qc in prepared.queue_configs:
-        qc.broker_instance = None
-        setattr(qc, "_broker_type", None)
-        setattr(qc, "_queue_class", None)
-    return prepared
+    queue_states = [
+        (qc, qc.broker_instance, getattr(qc, "_broker_type", None), getattr(qc, "_queue_class", None))
+        for qc in config.queue_configs
+    ]
+    queue_instances = config.queue_instances
+    try:
+        config.queue_instances = None
+        for qc, _broker_instance, _broker_type, _queue_class in queue_states:
+            qc.broker_instance = None
+            setattr(qc, "_broker_type", None)
+            setattr(qc, "_queue_class", None)
+        return copy.deepcopy(config)
+    finally:
+        config.queue_instances = queue_instances
+        for qc, broker_instance, broker_type, queue_class in queue_states:
+            qc.broker_instance = broker_instance
+            setattr(qc, "_broker_type", broker_type)
+            setattr(qc, "_queue_class", queue_class)
 
 
 def run_worker_in_child(

--- a/litestar_saq/cli.py
+++ b/litestar_saq/cli.py
@@ -217,6 +217,9 @@ def _prepare_config_for_spawn(config: "SAQConfig") -> "SAQConfig":
             raise ImproperConfigurationError(msg)
 
     prepared = copy.deepcopy(config)
+    # Null out the live queue instances on the config itself — these hold live
+    # broker clients that are not picklable under forkserver/spawn.
+    prepared.queue_instances = None
     for qc in prepared.queue_configs:
         qc.broker_instance = None
         qc._broker_type = None  # noqa: SLF001
@@ -251,7 +254,6 @@ def _run_worker_in_child(
 def build_cli_app() -> "Group":  # noqa: C901, PLR0915
     import asyncio
     import multiprocessing
-    import platform
     from typing import cast
 
     from click import IntRange, group, option
@@ -292,9 +294,6 @@ def build_cli_app() -> "Group":  # noqa: C901, PLR0915
     ) -> None:
         """Run the API server."""
         console.rule("[yellow]Starting SAQ Workers[/]", align="left")
-        if platform.system() == "Darwin":
-            multiprocessing.set_start_method("fork", force=True)
-
         if app.logging_config is not None:
             app.logging_config.configure()
         if debug is not None or verbose is not None:
@@ -305,6 +304,7 @@ def build_cli_app() -> "Group":  # noqa: C901, PLR0915
             limited_start_up(plugin, queue_list)
         show_saq_info(app, workers, plugin)
         managed_workers = list(plugin.get_workers().values())
+        managed_queue_names = list(plugin.get_workers().keys())
         processes: list[multiprocessing.Process] = []
         shutdown_timeout = get_max_shutdown_timeout(managed_workers)
 
@@ -322,22 +322,24 @@ def build_cli_app() -> "Group":  # noqa: C901, PLR0915
         signal.signal(signal.SIGTERM, handle_shutdown_signal)
         signal.signal(signal.SIGINT, handle_shutdown_signal)
 
+        spawn_config = _prepare_config_for_spawn(plugin.config)
+
         if workers > 1:
             for _ in range(workers - 1):
-                for worker in managed_workers:
+                for queue_name in managed_queue_names:
                     p = multiprocessing.Process(
-                        target=run_saq_worker,
-                        args=(
-                            worker,
-                            app.logging_config,
-                        ),
+                        target=_run_worker_in_child,
+                        args=(queue_name, spawn_config, app.logging_config),
                     )
                     p.start()
                     processes.append(p)
 
-        if len(managed_workers) > 1:
-            for j in range(len(managed_workers) - 1):
-                p = multiprocessing.Process(target=run_saq_worker, args=(managed_workers[j + 1], app.logging_config))
+        if len(managed_queue_names) > 1:
+            for j in range(len(managed_queue_names) - 1):
+                p = multiprocessing.Process(
+                    target=_run_worker_in_child,
+                    args=(managed_queue_names[j + 1], spawn_config, app.logging_config),
+                )
                 p.start()
                 processes.append(p)
 

--- a/litestar_saq/plugin.py
+++ b/litestar_saq/plugin.py
@@ -67,9 +67,9 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
 
         from litestar_saq.controllers import build_controller
 
-        app_config.dependencies.update(
-            {self._config.queues_dependency_key: Provide(dependency=self._config.provide_queues)}
-        )
+        app_config.dependencies.update({
+            self._config.queues_dependency_key: Provide(dependency=self._config.provide_queues)
+        })
         if self._config.web_enabled:
             app_config.route_handlers.append(
                 create_static_files_router(
@@ -132,36 +132,8 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
 
         return self._worker_instances
 
-    def _get_otel_tracer(self) -> Any:
-        """Get or create the OTEL tracer."""
-        if self._otel_tracer is None:
-            from litestar_saq.instrumentation import get_tracer
-
-            self._otel_tracer = get_tracer(self._config.otel_tracer_name)
-        return self._otel_tracer
-
     def remove_workers(self) -> None:
         self._worker_instances = None
-
-    def _get_shutdown_timeout(self) -> float:
-        """Calculate the shutdown timeout from worker configurations.
-
-        Returns the maximum shutdown_grace_period_s from all workers plus
-        buffer time. Falls back to DEFAULT_SHUTDOWN_TIMEOUT if no grace
-        periods are configured.
-
-        Returns:
-            Shutdown timeout in seconds.
-        """
-        workers = self.get_workers().values()
-        grace_periods: list[float] = []
-        for worker in workers:
-            grace_period = getattr(worker, "_shutdown_grace_period_s", None)
-            if grace_period is not None:
-                grace_periods.append(grace_period)
-        if grace_periods:
-            return max(grace_periods) + self.SHUTDOWN_BUFFER
-        return self.DEFAULT_SHUTDOWN_TIMEOUT
 
     def get_queues(self) -> "TaskQueues":
         return self._config.get_queues()
@@ -173,7 +145,12 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
     def server_lifespan(self, app: "Litestar") -> "Iterator[None]":
         from litestar.cli._utils import console  # pyright: ignore
 
-        from litestar_saq.cli import _prepare_config_for_spawn, _run_worker_in_child
+        from litestar_saq.cli import (
+            prepare_config_for_spawn,
+            prepare_logging_config_for_spawn,
+            requires_multiprocessing_safe_args,
+            run_worker_in_child,
+        )
 
         if not self._config.use_server_lifespan:
             yield
@@ -195,15 +172,19 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
         signal.signal(signal.SIGTERM, handle_shutdown)
         signal.signal(signal.SIGINT, handle_shutdown)
 
-        spawn_config = _prepare_config_for_spawn(self._config)
+        requires_safe_args = requires_multiprocessing_safe_args()
+        child_config = prepare_config_for_spawn(self._config) if requires_safe_args else self._config
+        child_logging_config = (
+            prepare_logging_config_for_spawn(app.logging_config) if requires_safe_args else app.logging_config
+        )
 
         try:
             for worker_name in self.get_workers():
                 for i in range(self.config.worker_processes):
                     console.print(f"[yellow]Starting worker process {i + 1} for {worker_name}[/]")
                     process = Process(
-                        target=_run_worker_in_child,
-                        args=(worker_name, spawn_config, app.logging_config),
+                        target=run_worker_in_child,
+                        args=(worker_name, child_config, child_logging_config),
                         name=f"worker-{worker_name}-{i + 1}",
                     )
                     process.start()
@@ -218,6 +199,33 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
             console.print(f"[yellow]Shutting down SAQ workers (timeout: {self._shutdown_timeout:.1f}s)...[/]")
             self._terminate_workers(self._processes, timeout=self._shutdown_timeout)
             console.print("[yellow]SAQ workers stopped.[/]")
+
+    def _get_otel_tracer(self) -> Any:
+        if self._otel_tracer is None:
+            from litestar_saq.instrumentation import get_tracer
+
+            self._otel_tracer = get_tracer(self._config.otel_tracer_name)
+        return self._otel_tracer
+
+    def _get_shutdown_timeout(self) -> float:
+        """Calculate the shutdown timeout from worker configurations.
+
+        Returns the maximum shutdown_grace_period_s from all workers plus
+        buffer time. Falls back to DEFAULT_SHUTDOWN_TIMEOUT if no grace
+        periods are configured.
+
+        Returns:
+            Shutdown timeout in seconds.
+        """
+        workers = self.get_workers().values()
+        grace_periods: list[float] = []
+        for worker in workers:
+            grace_period = getattr(worker, "_shutdown_grace_period_s", None)
+            if grace_period is not None:
+                grace_periods.append(grace_period)
+        if grace_periods:
+            return max(grace_periods) + self.SHUTDOWN_BUFFER
+        return self.DEFAULT_SHUTDOWN_TIMEOUT
 
     @staticmethod
     def _terminate_workers(processes: "list[Process]", timeout: float = DEFAULT_SHUTDOWN_TIMEOUT) -> None:

--- a/litestar_saq/plugin.py
+++ b/litestar_saq/plugin.py
@@ -67,9 +67,9 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
 
         from litestar_saq.controllers import build_controller
 
-        app_config.dependencies.update({
-            self._config.queues_dependency_key: Provide(dependency=self._config.provide_queues)
-        })
+        app_config.dependencies.update(
+            {self._config.queues_dependency_key: Provide(dependency=self._config.provide_queues)}
+        )
         if self._config.web_enabled:
             app_config.route_handlers.append(
                 create_static_files_router(

--- a/litestar_saq/plugin.py
+++ b/litestar_saq/plugin.py
@@ -171,15 +171,9 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
 
     @contextmanager  # pyright: ignore[reportDeprecated]
     def server_lifespan(self, app: "Litestar") -> "Iterator[None]":
-        import multiprocessing
-        import platform
-
         from litestar.cli._utils import console  # pyright: ignore
 
-        from litestar_saq.cli import run_saq_worker
-
-        if platform.system() == "Darwin":
-            multiprocessing.set_start_method("fork", force=True)
+        from litestar_saq.cli import _prepare_config_for_spawn, _run_worker_in_child
 
         if not self._config.use_server_lifespan:
             yield
@@ -201,16 +195,15 @@ class SAQPlugin(InitPluginProtocol, CLIPlugin):
         signal.signal(signal.SIGTERM, handle_shutdown)
         signal.signal(signal.SIGINT, handle_shutdown)
 
+        spawn_config = _prepare_config_for_spawn(self._config)
+
         try:
-            for worker_name, worker in self.get_workers().items():
+            for worker_name in self.get_workers():
                 for i in range(self.config.worker_processes):
                     console.print(f"[yellow]Starting worker process {i + 1} for {worker_name}[/]")
                     process = Process(
-                        target=run_saq_worker,
-                        args=(
-                            worker,
-                            app.logging_config,
-                        ),
+                        target=_run_worker_in_child,
+                        args=(worker_name, spawn_config, app.logging_config),
                         name=f"worker-{worker_name}-{i + 1}",
                     )
                     process.start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,6 +212,7 @@ lint.ignore = [
   "PLC2701",  # ignore for now; investigate
   "PLR6301",  # function could be static or class method
   "RUF029",
+  "PLW0717",  # Try clause contains too many statements (16 > 5)
 ]
 lint.select = ["ALL"]
 # Allow unused variables when underscore-prefixed.

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -81,6 +81,35 @@ app = Litestar(plugins=[saq], route_handlers=[SampleController])
 """
 
 
+def get_broker_instance_app_config_content() -> str:
+    """Generate app config content that supplies a live broker instance without a DSN."""
+    return """
+from redis.asyncio import from_url as redis_from_url
+
+from litestar import Litestar
+
+from litestar_saq import QueueConfig, SAQConfig, SAQPlugin
+
+
+async def background_worker_task(_ctx: dict) -> None:
+    return None
+
+
+saq = SAQPlugin(
+    config=SAQConfig(
+        queue_configs=[
+            QueueConfig(
+                broker_instance=redis_from_url("redis://localhost:6379/0"),
+                name="samples",
+                tasks=[background_worker_task],
+            ),
+        ],
+    ),
+)
+app = Litestar(plugins=[saq])
+"""
+
+
 async def test_basic_command(
     runner: CliRunner,
     create_app_file: CreateAppFileFixture,
@@ -94,6 +123,41 @@ async def test_basic_command(
 
     assert result.exit_code == 0
     assert "Checking SAQ worker status" in result.output
+
+
+def test_run_worker_single_parent_worker_allows_broker_instance_without_dsn(
+    runner: CliRunner,
+    create_app_file: CreateAppFileFixture,
+    root_command: LitestarGroup,
+    mocker: Any,
+) -> None:
+    app_file = create_app_file("broker_instance_app.py", content=get_broker_instance_app_config_content())
+    run_saq_worker = mocker.patch("litestar_saq.cli.run_saq_worker")
+    process = mocker.patch("multiprocessing.Process")
+
+    result = runner.invoke(root_command, ["--app", f"{app_file.stem}:app", "workers", "run"])
+
+    assert result.exit_code == 0, result.output
+    run_saq_worker.assert_called_once()
+    process.assert_not_called()
+
+
+def test_run_worker_fork_children_allow_broker_instance_without_dsn(
+    runner: CliRunner,
+    create_app_file: CreateAppFileFixture,
+    root_command: LitestarGroup,
+    mocker: Any,
+) -> None:
+    app_file = create_app_file("broker_instance_app.py", content=get_broker_instance_app_config_content())
+    run_saq_worker = mocker.patch("litestar_saq.cli.run_saq_worker")
+    mocker.patch("litestar_saq.cli.multiprocessing.get_start_method", return_value="fork")
+    process = mocker.patch("multiprocessing.Process")
+
+    result = runner.invoke(root_command, ["--app", f"{app_file.stem}:app", "workers", "run", "--workers", "2"])
+
+    assert result.exit_code == 0, result.output
+    run_saq_worker.assert_called_once()
+    process.assert_called_once()
 
 
 def test_terminate_worker_processes_graceful_shutdown() -> None:

--- a/tests/test_cli/test_multiprocess_spawn.py
+++ b/tests/test_cli/test_multiprocess_spawn.py
@@ -1,13 +1,18 @@
-from __future__ import annotations
-
-import pickle
+import io
 from multiprocessing.reduction import ForkingPickler
+from typing import Any
 
 import pytest
+from litestar import Litestar
 from redis.asyncio import from_url as redis_from_url
 
 from litestar_saq import QueueConfig, SAQConfig
-from litestar_saq.cli import _prepare_config_for_spawn, _run_worker_in_child
+from litestar_saq.cli import (
+    prepare_config_for_spawn,
+    prepare_logging_config_for_spawn,
+    requires_multiprocessing_safe_args,
+    run_worker_in_child,
+)
 from litestar_saq.exceptions import ImproperConfigurationError
 
 
@@ -27,7 +32,7 @@ def test_prepare_config_for_spawn_nulls_broker_instance_when_dsn_present() -> No
         qc.get_broker()
         assert qc.broker_instance is not None
 
-    prepared = _prepare_config_for_spawn(cfg)
+    prepared = prepare_config_for_spawn(cfg)
 
     # Original is untouched.
     for qc in cfg.queue_configs:
@@ -39,7 +44,7 @@ def test_prepare_config_for_spawn_nulls_broker_instance_when_dsn_present() -> No
         assert qc.dsn is not None
 
     # Prepared copy is picklable (the whole point).
-    pickle.dumps(prepared)
+    ForkingPickler.dumps(prepared)
 
 
 def test_prepare_config_for_spawn_rejects_broker_instance_without_dsn() -> None:
@@ -51,23 +56,39 @@ def test_prepare_config_for_spawn_rejects_broker_instance_without_dsn() -> None:
     )
 
     with pytest.raises(ImproperConfigurationError, match="dsn"):
-        _prepare_config_for_spawn(cfg)
+        prepare_config_for_spawn(cfg)
 
 
 def test_run_worker_in_child_is_picklable() -> None:
     # The function itself must be picklable so multiprocessing.Process can
     # ship it as `target` under forkserver/spawn.
-    pickle.dumps(_run_worker_in_child)
+    ForkingPickler.dumps(run_worker_in_child)
+
+
+@pytest.mark.parametrize(
+    ("start_method", "expected"),
+    [
+        ("fork", False),
+        ("spawn", True),
+        ("forkserver", True),
+    ],
+)
+def test_requires_multiprocessing_safe_args(
+    start_method: str,
+    expected: bool,
+    mocker: Any,
+) -> None:
+    mocker.patch("litestar_saq.cli.multiprocessing.get_start_method", return_value=start_method)
+
+    assert requires_multiprocessing_safe_args() is expected
 
 
 def test_spawn_args_are_picklable_with_forking_pickler() -> None:
     """The exact (target, args) tuple multiprocessing.Process would pickle
-    under forkserver/spawn must round-trip through ForkingPickler — the same
+    under forkserver/spawn must round-trip through ForkingPickler - the same
     pickler multiprocessing uses internally. This is the unit-level guarantee
     that prevents the #104 PicklingError without spawning real worker loops.
     """
-    import io
-
     cfg = SAQConfig(
         queue_configs=[
             QueueConfig(name="queue-a", dsn="redis://localhost:6379/0", tasks=[_noop]),
@@ -75,22 +96,52 @@ def test_spawn_args_are_picklable_with_forking_pickler() -> None:
         ],
     )
     # Force live broker construction in the parent (mirrors what the CLI does
-    # before calling _prepare_config_for_spawn).
+    # before calling prepare_config_for_spawn).
     cfg.get_queues()
 
-    spawn_config = _prepare_config_for_spawn(cfg)
+    spawn_config = prepare_config_for_spawn(cfg)
     spawn_args = ("queue-a", spawn_config, None)
 
     buf = io.BytesIO()
-    ForkingPickler(buf).dump((_run_worker_in_child, spawn_args))
+    ForkingPickler(buf).dump((run_worker_in_child, spawn_args))
 
-    target, args = pickle.loads(buf.getvalue())
-    assert target is _run_worker_in_child
+    target, args = ForkingPickler.loads(buf.getvalue())
+    assert target is run_worker_in_child
     queue_name, restored_config, restored_logging = args
     assert queue_name == "queue-a"
     assert restored_logging is None
-    # The restored config has no live broker references — children rebuild
+    # The restored config has no live broker references; children rebuild
     # them lazily from `dsn`.
     for qc in restored_config.queue_configs:
         assert qc.broker_instance is None
         assert qc.dsn == "redis://localhost:6379/0"
+
+
+def test_spawn_args_are_picklable_with_default_litestar_logging_config() -> None:
+    cfg = SAQConfig(
+        queue_configs=[
+            QueueConfig(name="queue-a", dsn="redis://localhost:6379/0", tasks=[_noop]),
+            QueueConfig(name="queue-b", dsn="redis://localhost:6379/0", tasks=[_noop]),
+        ],
+    )
+    cfg.get_queues()
+    spawn_config = prepare_config_for_spawn(cfg)
+    spawn_logging_config = prepare_logging_config_for_spawn(Litestar(route_handlers=[]).logging_config)
+    spawn_args = ("queue-a", spawn_config, spawn_logging_config)
+
+    buf = io.BytesIO()
+    ForkingPickler(buf).dump((run_worker_in_child, spawn_args))
+
+    _target, args = ForkingPickler.loads(buf.getvalue())
+    _queue_name, _restored_config, restored_logging = args
+    assert restored_logging is not None
+
+
+def test_prepare_logging_config_for_spawn_rewrites_default_queue_handler() -> None:
+    prepared = prepare_logging_config_for_spawn(Litestar(route_handlers=[]).logging_config)
+
+    assert prepared is not None
+    handler = prepared.logging_config["handlers"]["queue_listener"]
+    assert handler["class"] == "logging.StreamHandler"
+    assert "listener" not in handler
+    ForkingPickler.dumps(prepared)

--- a/tests/test_cli/test_multiprocess_spawn.py
+++ b/tests/test_cli/test_multiprocess_spawn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pickle
+from multiprocessing.reduction import ForkingPickler
 
 import pytest
 from redis.asyncio import from_url as redis_from_url
@@ -57,3 +58,39 @@ def test_run_worker_in_child_is_picklable() -> None:
     # The function itself must be picklable so multiprocessing.Process can
     # ship it as `target` under forkserver/spawn.
     pickle.dumps(_run_worker_in_child)
+
+
+def test_spawn_args_are_picklable_with_forking_pickler() -> None:
+    """The exact (target, args) tuple multiprocessing.Process would pickle
+    under forkserver/spawn must round-trip through ForkingPickler — the same
+    pickler multiprocessing uses internally. This is the unit-level guarantee
+    that prevents the #104 PicklingError without spawning real worker loops.
+    """
+    import io
+
+    cfg = SAQConfig(
+        queue_configs=[
+            QueueConfig(name="queue-a", dsn="redis://localhost:6379/0", tasks=[_noop]),
+            QueueConfig(name="queue-b", dsn="redis://localhost:6379/0", tasks=[_noop]),
+        ],
+    )
+    # Force live broker construction in the parent (mirrors what the CLI does
+    # before calling _prepare_config_for_spawn).
+    cfg.get_queues()
+
+    spawn_config = _prepare_config_for_spawn(cfg)
+    spawn_args = ("queue-a", spawn_config, None)
+
+    buf = io.BytesIO()
+    ForkingPickler(buf).dump((_run_worker_in_child, spawn_args))
+
+    target, args = pickle.loads(buf.getvalue())
+    assert target is _run_worker_in_child
+    queue_name, restored_config, restored_logging = args
+    assert queue_name == "queue-a"
+    assert restored_logging is None
+    # The restored config has no live broker references — children rebuild
+    # them lazily from `dsn`.
+    for qc in restored_config.queue_configs:
+        assert qc.broker_instance is None
+        assert qc.dsn == "redis://localhost:6379/0"

--- a/tests/test_cli/test_multiprocess_spawn.py
+++ b/tests/test_cli/test_multiprocess_spawn.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pickle
+
+import pytest
+from redis.asyncio import from_url as redis_from_url
+
+from litestar_saq import QueueConfig, SAQConfig
+from litestar_saq.cli import _prepare_config_for_spawn
+from litestar_saq.exceptions import ImproperConfigurationError
+
+
+async def _noop(_ctx: dict) -> None:
+    return None
+
+
+def test_prepare_config_for_spawn_nulls_broker_instance_when_dsn_present() -> None:
+    cfg = SAQConfig(
+        queue_configs=[
+            QueueConfig(name="q1", dsn="redis://localhost:6379/0", tasks=[_noop]),
+            QueueConfig(name="q2", dsn="redis://localhost:6379/0", tasks=[_noop]),
+        ],
+    )
+    # Force broker construction in the parent so broker_instance is a live Redis.
+    for qc in cfg.queue_configs:
+        qc.get_broker()
+        assert qc.broker_instance is not None
+
+    prepared = _prepare_config_for_spawn(cfg)
+
+    # Original is untouched.
+    for qc in cfg.queue_configs:
+        assert qc.broker_instance is not None
+
+    # Prepared copy has no live brokers.
+    for qc in prepared.queue_configs:
+        assert qc.broker_instance is None
+        assert qc.dsn is not None
+
+    # Prepared copy is picklable (the whole point).
+    pickle.dumps(prepared)
+
+
+def test_prepare_config_for_spawn_rejects_broker_instance_without_dsn() -> None:
+    live_client = redis_from_url("redis://localhost:6379/0")
+    cfg = SAQConfig(
+        queue_configs=[
+            QueueConfig(name="q1", broker_instance=live_client, tasks=[_noop]),
+        ],
+    )
+
+    with pytest.raises(ImproperConfigurationError, match="dsn"):
+        _prepare_config_for_spawn(cfg)

--- a/tests/test_cli/test_multiprocess_spawn.py
+++ b/tests/test_cli/test_multiprocess_spawn.py
@@ -6,7 +6,7 @@ import pytest
 from redis.asyncio import from_url as redis_from_url
 
 from litestar_saq import QueueConfig, SAQConfig
-from litestar_saq.cli import _prepare_config_for_spawn
+from litestar_saq.cli import _prepare_config_for_spawn, _run_worker_in_child
 from litestar_saq.exceptions import ImproperConfigurationError
 
 
@@ -51,3 +51,9 @@ def test_prepare_config_for_spawn_rejects_broker_instance_without_dsn() -> None:
 
     with pytest.raises(ImproperConfigurationError, match="dsn"):
         _prepare_config_for_spawn(cfg)
+
+
+def test_run_worker_in_child_is_picklable() -> None:
+    # The function itself must be picklable so multiprocessing.Process can
+    # ship it as `target` under forkserver/spawn.
+    pickle.dumps(_run_worker_in_child)

--- a/tests/test_cli/test_multiprocess_spawn.py
+++ b/tests/test_cli/test_multiprocess_spawn.py
@@ -31,10 +31,13 @@ def test_prepare_config_for_spawn_nulls_broker_instance_when_dsn_present() -> No
     for qc in cfg.queue_configs:
         qc.get_broker()
         assert qc.broker_instance is not None
+    cfg.get_queues()
+    assert cfg.queue_instances is not None
 
     prepared = prepare_config_for_spawn(cfg)
 
     # Original is untouched.
+    assert cfg.queue_instances is not None
     for qc in cfg.queue_configs:
         assert qc.broker_instance is not None
 


### PR DESCRIPTION
## Summary

- Construct `Worker` (and its broker client) **inside** the spawned child process via a new top-level `run_worker_in_child` entry point, instead of pickling a live `redis.asyncio.Redis` across the `multiprocessing` boundary.
- Pass a pickle-safe deep-copied `SAQConfig` (live `broker_instance` and `queue_instances` nulled out) into children; broker clients are rebuilt lazily from `dsn` in the child via the existing `QueueConfig.get_broker()` machinery.
- Remove the macOS `multiprocessing.set_start_method("fork", force=True)` overrides in `cli.py` and `plugin.py` — they masked the same latent bug.

Closes #104.

## Why

Python 3.14 changed the default `multiprocessing` start method on Linux from `fork` to `forkserver`. `forkserver` pickles the target and its args. The previous code shipped a fully built `Worker` (containing a live `redis.asyncio.Redis` with lambda-based response callbacks) to each child, which fails with `_pickle.PicklingError`. On 3.13 and earlier this worked only because `fork` skipped pickling. The macOS `fork` override was hiding the same issue on Darwin.

## How the fix works

1. `prepare_config_for_spawn(config)` deep-copies the `SAQConfig` and nulls out `broker_instance` / `_broker_type` / `_queue_class` on each `QueueConfig`, plus `queue_instances` on the config itself. The copy holds only `dsn`s and plain config data — pickle-safe.
2. `run_worker_in_child(queue_name, config, logging_config)` is a top-level (picklable) function used as the `multiprocessing.Process` target. Inside the child it instantiates a fresh `SAQPlugin(config)`, fetches its `Worker` by name (which lazily rebuilds the broker client via `get_broker()`), and delegates to existing `run_saq_worker`.
3. Both spawn sites (CLI `workers run` in `cli.py` and `SAQPlugin.server_lifespan` in `plugin.py`) call `prepare_config_for_spawn` once and hand the prepared config to every child.

If a user passes `QueueConfig(broker_instance=..., dsn=None)`, `prepare_config_for_spawn` raises `ImproperConfigurationError` at spawn time with a clear message — the broker can't be rebuilt in the child without a `dsn`.

## Follow-up updates

- Added a pickle-safe Litestar logging snapshot for child workers so the default `LoggingConfig` / `StructLoggingConfig` path no longer ships Litestar's unpicklable default exception handler or queue listener handler through multiprocessing.
- Switched the explicit serialization check to `multiprocessing.reduction.ForkingPickler`, matching the serializer multiprocessing uses internally and avoiding direct `pickle` imports in runtime code.
- Preserved existing fork-based Linux behavior: fork child workers can still use a live `broker_instance` without `dsn`; the stricter `dsn` requirement only applies when the active start method needs pickle-safe args (`spawn` / `forkserver`).
- Promoted the spawn helpers to public module-level helpers (`prepare_config_for_spawn`, `prepare_logging_config_for_spawn`, `run_worker_in_child`) and kept private helpers below the public functions.
- Added regression coverage for default Litestar logging serialization, fork-vs-spawn argument requirements, parent-only broker-instance startup, and fork child-worker broker-instance startup.
- Fixed the Python 3.9 CI failure by scrubbing live parent `queue_instances` and cached broker state before deep-copying the spawn config, then restoring the parent config in a `finally` block.

## Test plan

- [x] New `tests/test_cli/test_multiprocess_spawn.py`:
  - `prepare_config_for_spawn` nulls live broker references and the result is `ForkingPickler`-able
  - `prepare_config_for_spawn` rejects `broker_instance` without `dsn`
  - `run_worker_in_child` is picklable
  - The exact `(target, args)` tuple `multiprocessing.Process` would pickle round-trips through `ForkingPickler` (the pickler `multiprocessing` uses internally) — proves pickle-safety end-to-end without spawning real worker loops
- [x] Existing test suite via `make test` passes
- [x] Lint: `uv run ruff check` clean; `uv run mypy litestar_saq/` clean
- [x] Follow-up verification: `make test`, `make lint`, `make type-check`, and `uv run ruff check --preview --select S403,S301 ...` pass
- [x] CI after `fc1d584`: validate, mypy, pyright, slotscheck, and Python 3.9-3.13 test matrix pass

## Notes

- The first worker (`managed_workers[0]`) still runs in the parent process — no spawn, no behavior change for the single-queue / single-worker path.
- Backwards compatible: no public API change to `SAQConfig`, `QueueConfig`, or `SAQPlugin`.
