### PR TITLE
fix: Avoid HeartbeatManager crash log during shutdown

### DIFF
--- a/litestar_saq/heartbeat.py
+++ b/litestar_saq/heartbeat.py
@@ -94,6 +94,7 @@ class HeartbeatManager:
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._wake_event: Optional[asyncio.Event] = None
         self._jobs: dict[str, Job] = {}  # job_id -> Job reference
         self._jobs_lock = threading.Lock()
 
@@ -126,9 +127,9 @@ class HeartbeatManager:
         """
         self._stop_event.set()
         # Interrupt the event loop to wake from asyncio.sleep()
-        if self._loop is not None:
+        if self._loop is not None and self._wake_event is not None:
             with contextlib.suppress(RuntimeError):
-                self._loop.call_soon_threadsafe(self._loop.stop)
+                self._loop.call_soon_threadsafe(self._wake_event.set)
         if self._thread is not None:
             self._thread.join(timeout=5.0)
             logger.debug("HeartbeatManager stopped")
@@ -177,17 +178,29 @@ class HeartbeatManager:
         self._loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self._loop)
         try:
+            self._wake_event = asyncio.Event()
             self._loop.run_until_complete(self._manager_loop())
         except Exception:
             logger.exception("HeartbeatManager thread crashed")
         finally:
             self._loop.close()
+            self._loop = None
+            self._wake_event = None
 
     async def _manager_loop(self) -> None:
         """Main loop - flush pending heartbeats every interval."""
+        if self._wake_event is None:
+            return
+
         while not self._stop_event.is_set():
-            # Use wait with timeout for responsive shutdown
-            await asyncio.sleep(self._flush_interval)
+            # Wait for either the next flush interval or a shutdown wakeup.
+            try:
+                await asyncio.wait_for(self._wake_event.wait(), timeout=self._flush_interval)
+            except asyncio.TimeoutError:
+                pass
+            else:
+                self._wake_event.clear()
+
             if not self._stop_event.is_set():
                 await self._flush()
 

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,6 +1,7 @@
 """Tests for HeartbeatManager."""
 
 import asyncio
+import logging
 import threading
 import time
 from unittest.mock import AsyncMock, Mock
@@ -10,6 +11,13 @@ import pytest
 from litestar_saq.heartbeat import HeartbeatManager
 
 pytestmark = pytest.mark.anyio
+
+
+def _wait_for_manager_loop(manager: HeartbeatManager) -> None:
+    deadline = time.monotonic() + 1.0
+    while manager._wake_event is None and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert manager._wake_event is not None
 
 
 # =============================================================================
@@ -167,6 +175,35 @@ def test_stop_terminates_thread() -> None:
 
     manager.stop()
 
+    assert not manager._thread.is_alive() if manager._thread else True
+
+
+def test_stop_does_not_log_thread_crashed(caplog: pytest.LogCaptureFixture) -> None:
+    """Test normal shutdown does not log the manager thread as crashed."""
+    queue_mock = Mock()
+    manager = HeartbeatManager(queue=queue_mock, flush_interval=30.0)
+    caplog.set_level(logging.ERROR, logger="litestar_saq.heartbeat")
+
+    manager.start()
+    _wait_for_manager_loop(manager)
+    manager.stop()
+
+    assert "HeartbeatManager thread crashed" not in caplog.text
+    assert not [record for record in caplog.records if record.levelno >= logging.ERROR]
+
+
+def test_stop_wakes_sleeping_manager_without_waiting_flush_interval() -> None:
+    """Test stop() wakes the manager even when the flush interval is long."""
+    queue_mock = Mock()
+    manager = HeartbeatManager(queue=queue_mock, flush_interval=30.0)
+
+    manager.start()
+    _wait_for_manager_loop(manager)
+    started = time.monotonic()
+
+    manager.stop()
+
+    assert time.monotonic() - started < 1.0
     assert not manager._thread.is_alive() if manager._thread else True
 
 


### PR DESCRIPTION
Closes #110

## Description

- Updates `HeartbeatManager.stop()` so normal shutdown wakes the manager loop instead of stopping the event loop directly.
- This avoids logging `HeartbeatManager thread crashed` for normal worker shutdown / Ctrl-C.
- Keeps crash logging for unexpected exceptions.
- Adds regression tests for clean shutdown logging and fast shutdown with a long heartbeat flush interval.

